### PR TITLE
docs: add link to suggest game plan in Issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ Rogue Outlaw is a fast-paced, top-down Wild West roguelike inspired by Sword Rog
 * Procedurally spawned enemies
 * Simple, minimalistic Wild West aesthetic
 
----
+### Suggest some game plan in [GitHub Issues](https://github.com/Jabir-A-H/rogue-outlaw/issues)
 
 *The End*


### PR DESCRIPTION
Add a prominent call-to-action in the README that points contributors
and players to the project's GitHub Issues for suggesting game plans.
This provides a clear, centralized place for feedback and feature
proposals and encourages community participation.